### PR TITLE
Add normative references for 3 json schema versions

### DIFF
--- a/common.js
+++ b/common.js
@@ -41,22 +41,19 @@ var vcwg = {
       publisher: "OpenJS Foundation"
     },
     "JSON-SCHEMA-2020-12": {
-      href: "https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01",
-      date: "December 2022",
-      title: "JSON Schema: A Media Type for Describing JSON Documents",
-      publisher: "IETF"
+      href: "https://json-schema.org/draft/2020-12/release-notes.html",
+      title: "JSON Schema 2020-12 Release Notes",
+      publisher: "OpenJS Foundation"
     },
     "JSON-SCHEMA-2019-09": {
-      href: "https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-02",
-      date: "March 2020",
-      title: "JSON Schema: A Media Type for Describing JSON Documents",
-      publisher: "IETF"
+      href: "https://json-schema.org/draft/2019-09/release-notes.html",
+      title: "JSON Schema 2019-09 Release Notes",
+      publisher: "OpenJS Foundation"
     },
     "JSON-SCHEMA-DRAFT-7": {
-      href: "https://tools.ietf.org/html/draft-handrews-json-schema-01",
-      date: "September 2018",
-      title: "JSON Schema: A Media Type for Describing JSON Documents",
-      publisher: "IETF"
+      href: "https://json-schema.org/draft-07/json-schema-release-notes.html",
+      title: "JSON Schema Draft-07 Release Notes",
+      publisher: "OpenJS Foundation"
     },
     "DID-CORE": {
       href: "https://w3c.github.io/did-core/",

--- a/common.js
+++ b/common.js
@@ -40,6 +40,24 @@ var vcwg = {
       title: "JSON Schema: A Media Type for Describing JSON Documents",
       publisher: "OpenJS Foundation"
     },
+    "JSON-SCHEMA-2020-12": {
+      href: "https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01",
+      date: "December 2022",
+      title: "JSON Schema: A Media Type for Describing JSON Documents",
+      publisher: "IETF"
+    },
+    "JSON-SCHEMA-2019-09": {
+      href: "https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-02",
+      date: "March 2020",
+      title: "JSON Schema: A Media Type for Describing JSON Documents",
+      publisher: "IETF"
+    },
+    "JSON-SCHEMA-DRAFT-7": {
+      href: "https://tools.ietf.org/html/draft-handrews-json-schema-01",
+      date: "September 2018",
+      title: "JSON Schema: A Media Type for Describing JSON Documents",
+      publisher: "IETF"
+    },
     "DID-CORE": {
       href: "https://w3c.github.io/did-core/",
       title: "Decentralized Identifiers (DIDs) v1.0",

--- a/index.html
+++ b/index.html
@@ -339,13 +339,15 @@
                 <tr>
                    <th style="white-space: nowrap">JSON Schema Specification</th>
                    <th>Date of Publication</th>
+                   <th>$schema URI</th>
                    <th>References</th>
                 </tr>
              </thead>
              <tbody>
                 <tr>
-                   <td><a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01">draft-bhutton-json-schema-01</a></td>
+                   <td>[[JSON-SCHEMA-2020-12]]</td>
                    <td>10 June 2022</td>
+                   <td><a href="https://json-schema.org/draft/2020-12/schema">https://json-schema.org/draft/2020-12/schema</a></td>
                    <td>
                       • <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01">JSON Schema: A Media Type for Describing JSON Documents</a></br>
                       • <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-01">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a></br>
@@ -353,28 +355,27 @@
                    </td>
                 </tr>
                 <tr>
-                   <td><a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00">Draft 2020-12, draft-bhutton-json-schema-00</a></td>
-                   <td>11 June 2021</td>
-                   <td>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00">JSON Schema: A Media Type for Describing JSON Documents</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-relative-json-pointer-00">Relative JSON Pointers</a>
-                   </td>
-                </tr>
-                <tr>
-                   <td><a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-02">Draft 2019-09, Draft 8</a></td>
+                   <td>[[JSON-SCHEMA-2019-09]]</td>
                    <td>19 March 2020</td>
+                   <td><a href="https://json-schema.org/draft/2019-09/schema">https://json-schema.org/draft/2019-09/schema</a></td>
                    <td>
                       • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-02">JSON Schema: A Media Type for Describing JSON Documents</a></br>
                       • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-02">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-hyperschema-02">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON</a>
+                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-02">Relative JSON Pointers</a>
+                   </td>
+                </tr>
+                <tr>
+                   <td>[[JSON-SCHEMA-DRAFT-7]]</td>
+                   <td>20 September 2018</td>
+                   <td><a href="http://json-schema.org/draft-07/schema#">http://json-schema.org/draft-07/schema#</a></td>
+                   <td>
+                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-01">JSON Schema: A Media Type for Describing JSON Documents</a></br>
+                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a></br>
+                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-hyperschema-01">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON</a>
                    </td>
                 </tr>
              </tbody>
           </table>
-          <p class="issue" data-number="133">
-            Write considerations for normatively referencing JSON Schema.
-          </p>
           <section class="normative">
             <h3>Reserved Keywords</h3>
             <p>

--- a/index.html
+++ b/index.html
@@ -340,7 +340,6 @@
                    <th style="white-space: nowrap">JSON Schema Specification</th>
                    <th>Date of Publication</th>
                    <th>$schema URI</th>
-                   <th>References</th>
                 </tr>
              </thead>
              <tbody>
@@ -348,31 +347,16 @@
                    <td>[[JSON-SCHEMA-2020-12]]</td>
                    <td>10 June 2022</td>
                    <td><a href="https://json-schema.org/draft/2020-12/schema">https://json-schema.org/draft/2020-12/schema</a></td>
-                   <td>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01">JSON Schema: A Media Type for Describing JSON Documents</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-01">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-bhutton-relative-json-pointer-00">Relative JSON Pointers</a>
-                   </td>
                 </tr>
                 <tr>
                    <td>[[JSON-SCHEMA-2019-09]]</td>
                    <td>19 March 2020</td>
                    <td><a href="https://json-schema.org/draft/2019-09/schema">https://json-schema.org/draft/2019-09/schema</a></td>
-                   <td>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-02">JSON Schema: A Media Type for Describing JSON Documents</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-02">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-02">Relative JSON Pointers</a>
-                   </td>
                 </tr>
                 <tr>
                    <td>[[JSON-SCHEMA-DRAFT-7]]</td>
                    <td>20 September 2018</td>
                    <td><a href="http://json-schema.org/draft-07/schema#">http://json-schema.org/draft-07/schema#</a></td>
-                   <td>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-01">JSON Schema: A Media Type for Describing JSON Documents</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01">JSON Schema Validation: A Vocabulary for Structural Validation of JSON</a></br>
-                      • <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-hyperschema-01">JSON Hyper-Schema: A Vocabulary for Hypermedia Annotation of JSON</a>
-                   </td>
                 </tr>
              </tbody>
           </table>


### PR DESCRIPTION
fix #133


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/170.html" title="Last updated on Jul 5, 2023, 8:26 PM UTC (064c8f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/170/9a34f77...064c8f9.html" title="Last updated on Jul 5, 2023, 8:26 PM UTC (064c8f9)">Diff</a>