### PR TITLE
Update language around the defined types and their usages

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,8 +158,12 @@
                is <code>https://www.w3.org/TR/vc-json-schema/#JsonSchema2023</code>.
             </p>
             <p>
-               <b>JsonSchema2023</b> is for the validation of W3C Verifiable Credentials, based
-               on JSON Schema. The version of [[JSON-Schema]] can be any version noted in the section
+               <b>JsonSchema2023</b> is used for the validation of W3C Verifiable Credentials using
+               JSON Schema. When dereferencing the <code>id</code> property associated with the
+               <code>JsonSchema2023</code> <code>type</code> value the result is a valid JSON
+               Schema document according to its specification version.
+            <p>
+               The specification version of [[JSON-Schema]] can be any version noted in the section
                on <a href="#json-schema-specifications">JSON Schema Specifications</a>.
             </p>
             <p>
@@ -209,6 +213,11 @@
               </pre>
             </p>
             <p>
+              <p>
+               Upon dereferencing the value of the <code>id</code> <code>https://example.com/schemas/email.json</code>,
+               a process also be referred to as <a>schema resolution</a>, the following JSON Schema 
+               document is returned:
+              </p>
               <pre class="example" title="Example Email JSON Schema">
               {
                 "$id": "https://example.com/schemas/email.json",
@@ -241,9 +250,16 @@
                is <code>https://www.w3.org/TR/vc-json-schema/#VerifiableCredentialSchema2023</code>.
             </p>
             <p>
-               <b>VerifiableCredentialSchema2023</b> is used for the validation of W3C Verifiable Credentials, based
-               on representing JSON Schema in a <a>verifiable credential</a>. The version of [[JSON-Schema]]
-               can be any version noted in the section on <a href="#json-schema-specifications">JSON Schema Specifications</a>.
+               <b>VerifiableCredentialSchema2023</b> is used for the validation of W3C Verifiable Credentials using
+               JSON Schema, where the JSON Schema is contained with a <a>verifiable credential</a>.
+               When dereferencing the <code>id</code> property associated with the
+               <code>VerifiableCredentialSchema2023</code> <code>type</code> value the result is a valid 
+               <a>verifiable credential</a>. The resulting <a>verifiable credential</a> MUST NOT
+               have a <code>credentialSubject</code> property and it MUST have a <code>jsonSchema</code>
+               property containing a valid JSON Schema, as exemplified below.
+            <p>
+               The specification version of [[JSON-Schema]] can be any version noted in the section
+               on <a href="#json-schema-specifications">JSON Schema Specifications</a>.
             </p>
             <p>
              <table class="simple">
@@ -291,6 +307,11 @@
               </pre>
             </p>
             <p>
+              <p>
+               Upon dereferencing the value of the <code>id</code> <code>https://example.com/credentials/3734</code>,
+               a process also be referred to as <a>schema resolution</a>, the following verifiable credential,
+               representing a JSON Schema, is returned:
+              </p>
               <pre class="example" title="Example Email Credential Schema">
               {
                 "@context": [
@@ -301,7 +322,7 @@
                 "type": ["VerifiableCredential", "VerifiableCredentialSchema2023"],
                 "issuer": "https://example.com/issuers/14",
                 "issuanceDate": "2010-01-01T19:23:24Z",
-                "credentialSubject": {
+                "jsonSchema": {
                   "$id": "https://example.com/schemas/email-credential-schema.json",
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "name": "EmailCredential",

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
          <p>
             The following sections outline the data models for this document, of which there are two:
             <code>JsonSchema2023</code> for usage of a [[JSON-Schema]] directly in a <code>credentialSchema</code>
-            property, and <code>VerifiableCredentialSchema2023</code> for usage of a [[JSON-Schema]] represented as a
+            property, and <code>JsonSchemaCredential2023</code> for usage of a [[JSON-Schema]] represented as a
             <a>verifiable credential</a>.
          </p>
          <section>
@@ -244,19 +244,26 @@
             </p>
          </section>
          <section>
-            <h3>VerifiableCredentialSchema2023</h3>
+            <h3>JsonSchemaCredential2023</h3>
             <p>
                This <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
-               is <code>https://www.w3.org/ns/credentials#VerifiableCredentialSchema2023</code>.
+               is <code>https://www.w3.org/ns/credentials#JsonSchemaCredential2023</code>.
             </p>
             <p>
-               <b>VerifiableCredentialSchema2023</b> is used for the validation of W3C Verifiable Credentials using
+               <b>JsonSchemaCredential2023</b> is used for the validation of W3C Verifiable Credentials using
                JSON Schema, where the JSON Schema is contained with a <a>verifiable credential</a>.
                When dereferencing the <code>id</code> property associated with the
-               <code>VerifiableCredentialSchema2023</code> <code>type</code> value the result is a valid 
-               <a>verifiable credential</a>. The resulting <a>verifiable credential</a> MUST NOT
-               have a <code>credentialSubject</code> property and it MUST have a <code>jsonSchema</code>
-               property containing a valid JSON Schema, as exemplified below.
+               <code>JsonSchemaCredential2023</code> <code>type</code> value the result is a valid 
+               <a>verifiable credential</a>. The resulting <a>verifiable credential</a>'s  
+               <code>credentialSubject</code> property MUST contain a two properties:
+               <li><code>type</code> – the value of which MUST be <code>JsonSchema2023</code></li>
+               <li><code>jsonSchema</code> – an object which contains a valid JSON Schema</li>
+            </p>
+            <p>
+               The <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
+               for using the <code>jsonSchema</code> property within the <code>credentialSubject</code>
+               of a verifiable credential is <code>https://www.w3.org/ns/credentials#JsonSchema</code>.
+            </p>
             <p>
                The specification version of [[JSON-Schema]] can be any version noted in the section
                on <a href="#json-schema-specifications">JSON Schema Specifications</a>.
@@ -278,14 +285,14 @@
                    </tr>
                    <tr>
                       <td>type</td>
-                      <td>The <code>type</code> property MUST be VerifiableCredentialSchema2023</td>
+                      <td>The <code>type</code> property MUST be JsonSchemaCredential2023</td>
                    </tr>
                 </tbody>
                </table>
             </p>
                An example of utilizing the VC Data Model's <code>credentialSchema</code>
                is provided below:
-               <pre class="example" title="Example VerifiableCredentialSchema2023">
+               <pre class="example" title="Example JsonSchemaCredential2023">
                {
                  "@context": [
                    "https://www.w3.org/ns/credentials/v2",
@@ -301,7 +308,7 @@
                  },
                  "credentialSchema": {
                    "id": "https://example.com/credentials/3734",
-                   "type": "VerifiableCredentialSchema2023"
+                   "type": "JsonSchemaCredential2023"
                  }
                }
               </pre>
@@ -319,33 +326,37 @@
                     "https://www.w3.org/ns/credentials/examples/v2"
                 ],
                 "id": "https://example.com/credentials/3734",
-                "type": ["VerifiableCredential", "VerifiableCredentialSchema2023"],
+                "type": ["VerifiableCredential", "JsonSchemaCredential2023"],
                 "issuer": "https://example.com/issuers/14",
                 "issuanceDate": "2010-01-01T19:23:24Z",
-                "jsonSchema": {
-                  "$id": "https://example.com/schemas/email-credential-schema.json",
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "name": "EmailCredential",
-                  "description": "EmailCredential using VerifiableCredentialSchema2023",
-                  "type": "object",
-                  "properties": {
-                    "credentialSubject": {
-                      "type": "object",
-                      "properties": {
-                        "emailAddress": {
-                          "type": "string",
-                          "format": "email"
-                        }
-                      },
-                      "required": ["emailAddress"]
-                    }
+                "credentialSubject": {
+                  "id": "https://example.com/schemas/email-credential-schema.json",
+                  "type": "JsonSchema2023",
+                  "jsonSchema": {
+                     "$id": "https://example.com/schemas/email-credential-schema.json",
+                     "$schema": "https://json-schema.org/draft/2020-12/schema",
+                     "name": "EmailCredential",
+                     "description": "EmailCredential using JsonSchemaCredential2023",
+                     "type": "object",
+                     "properties": {
+                       "credentialSubject": {
+                         "type": "object",
+                         "properties": {
+                           "emailAddress": {
+                             "type": "string",
+                             "format": "email"
+                           }
+                         },
+                         "required": ["emailAddress"]
+                       }
+                     }
                   }
                 }
               }
               </pre>
             </p>
             <p class="issue" data-number="159">
-               Add language about CredentialSchema2023 credentials having a credentialSchema property
+               Add language about JsonSchemaCredential2023 credentials having a credentialSchema property
                and the risks of nesting.
             </p>
          </section>
@@ -465,7 +476,7 @@
           <h3>Integrity Validation</h3>
           <p>
             Credential Schemas MAY be packaged as <a>verifiable credentials</a> as defined
-            by usage of the <a href="#verifiablecredentialschema2023">VerifiableCredentialSchema2023</a> type.
+            by usage of the <a href="#jsonschemacredential2023">JsonSchemaCredential2023</a> type.
             The credential containing a <a>credential schema</a> may include a proof, either
             embedded according to [[VC-DATA-INTEGRITY]] or packaged as a [[VC-JWT]].
           </p>
@@ -735,7 +746,7 @@
                 },
                 "credentialSchema": {
                     "id": "multiple-credential-schema-test",
-                    "type": "VerifiableCredentialSchema2023"
+                    "type": "JsonSchemaCredential2023"
                 },
                 "proof": { ... }
             }

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
             <h3>JsonSchema2023</h3>
             <p>
                This <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
-               is <code>https://www.w3.org/ns/credentials#JsonSchema2023</code>.
+               is <code>https://www.w3.org/TR/vc-json-schema/#JsonSchema2023</code>.
             </p>
             <p>
                <b>JsonSchema2023</b> is for the validation of W3C Verifiable Credentials, based
@@ -238,7 +238,7 @@
             <h3>VerifiableCredentialSchema2023</h3>
             <p>
                This <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
-               is <code>https://www.w3.org/ns/credentials#VerifiableCredentialSchema2023</code>.
+               is <code>https://www.w3.org/TR/vc-json-schema/#VerifiableCredentialSchema2023</code>.
             </p>
             <p>
                <b>VerifiableCredentialSchema2023</b> is used for the validation of W3C Verifiable Credentials, based

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
                    "https://www.w3.org/ns/credentials/examples/v2"
                  ],
                  "id": "https://example.com/credentials/3733",
-                 "type": ["VerifiableCredential", "EmailCredential"],
+                 "type": ["VerifiableCredential", "JsonSchemaCredential2023", "EmailCredential"],
                  "issuer": "https://example.com/issuers/14",
                  "issuanceDate": "2010-01-01T19:23:24Z",
                  "credentialSubject": {

--- a/index.html
+++ b/index.html
@@ -256,8 +256,10 @@
                <code>JsonSchemaCredential2023</code> <code>type</code> value the result is a valid 
                <a>verifiable credential</a>. The resulting <a>verifiable credential</a>'s  
                <code>credentialSubject</code> property MUST contain a two properties:
-               <li><code>type</code> – the value of which MUST be <code>JsonSchema2023</code></li>
-               <li><code>jsonSchema</code> – an object which contains a valid JSON Schema</li>
+               <ul>
+                  <li><code>type</code> – the value of which MUST be <code>JsonSchema2023</code></li>
+                  <li><code>jsonSchema</code> – an object which contains a valid JSON Schema</li>
+               </ul>
             </p>
             <p>
                The <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
             <h3>JsonSchema2023</h3>
             <p>
                This <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
-               is <code>https://www.w3.org/TR/vc-json-schema/#JsonSchema2023</code>.
+               is <code>https://www.w3.org/ns/credentials/#JsonSchema2023</code>.
             </p>
             <p>
                <b>JsonSchema2023</b> is used for the validation of W3C Verifiable Credentials using
@@ -247,7 +247,7 @@
             <h3>VerifiableCredentialSchema2023</h3>
             <p>
                This <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
-               is <code>https://www.w3.org/TR/vc-json-schema/#VerifiableCredentialSchema2023</code>.
+               is <code>https://www.w3.org/ns/credentials#VerifiableCredentialSchema2023</code>.
             </p>
             <p>
                <b>VerifiableCredentialSchema2023</b> is used for the validation of W3C Verifiable Credentials using

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
                    "https://www.w3.org/ns/credentials/examples/v2"
                  ],
                  "id": "https://example.com/credentials/3733",
-                 "type": ["VerifiableCredential", "JsonSchemaCredential2023", "EmailCredential"],
+                 "type": ["VerifiableCredential", "ExampleEmailCredential"],
                  "issuer": "https://example.com/issuers/14",
                  "issuanceDate": "2010-01-01T19:23:24Z",
                  "credentialSubject": {

--- a/terms.html
+++ b/terms.html
@@ -158,4 +158,8 @@ or fetching, a URL are defined by the URL [=url/scheme=]. This specification
 does not use the term URI or IRI because those terms have been deemed to be
 confusing to Web developers.
   </dd>
+    <dt><dfn data-lt="resolution|schema resolution">schema resolution</dfn></dt>
+  <dd>
+The process that takes as its input a <a>URL</a> and returns a <a>credential schema</a>.
+  </dd>
 </dl>


### PR DESCRIPTION
Fix #172 #178 

I believe this needs a change to the core vocab to add a new property `jsonSchema` with the `type` as `@json`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/186.html" title="Last updated on Jul 26, 2023, 3:40 PM UTC (21ff4f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/186/2743534...21ff4f1.html" title="Last updated on Jul 26, 2023, 3:40 PM UTC (21ff4f1)">Diff</a>