### PR TITLE
Rename IRI to URL and point to RFC

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@
                <p>
                   It is RECOMMENDED that the value of the <code>$id</code> property match the <code>id</code>
                   value in the <code>credentialSchema</code> object of a <a>verifiable credential</a>, and
-                  that the value of the <code>$id</code> is a dereferenceable URL [[rfc3987]].
+                  that the value of the <code>$id</code> is a dereferenceable URL [[URL]].
                </p>
             </section>
             <section>

--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@
                <p>
                   It is RECOMMENDED that the value of the <code>$id</code> property match the <code>id</code>
                   value in the <code>credentialSchema</code> object of a <a>verifiable credential</a>, and
-                  that the value of the <code>$id</code> is a dereferenceable IRI.
+                  that the value of the <code>$id</code> is a dereferenceable URL [[rfc3987]].
                </p>
             </section>
             <section>


### PR DESCRIPTION
Fixes #176 by adding the RFC. The term definition for URL says we will not use the term IRI, so removed it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/188.html" title="Last updated on Jul 31, 2023, 7:19 PM UTC (38c46ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/188/2d2615f...38c46ad.html" title="Last updated on Jul 31, 2023, 7:19 PM UTC (38c46ad)">Diff</a>