### PR TITLE
Guidance on using JsonSchemaCredential

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,7 +304,7 @@
                    </tr>
                    <tr>
                       <td>credentialSubject.id</td>
-                      <td>The <code>credentialSubject</code>'s <code>id</code> property MUST be follow the guidance
+                      <td>The <code>credentialSubject</code>'s <code>id</code> property MUST follow the guidance
                         provided for <a data-cite="vc-data-model#identifiers">identifiers</a> in the [[VC-DATA-MODEL-2]] 
                         specification.</td>
                    </tr>

--- a/index.html
+++ b/index.html
@@ -286,8 +286,9 @@
                the value MUST match the <code>$id</code> property in the <code>jsonSchema</code> property.
             </p>
             <p>
-               Any version of [[JSON-Schema]] can be used from the section
-               on <a href="#json-schema-specifications">JSON Schema Specifications</a>.
+               Any version of [[JSON-Schema]] in the section on
+               <a href="#json-schema-specifications">JSON Schema Specifications</a>
+               can be used.
             </p>
             <p>
              <table class="simple">

--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
             <p>
                The <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
                for using the <code>jsonSchema</code> property within the <code>credentialSubject</code>
-               of a verifiable credential is <code>https://www.w3.org/ns/credentials#JsonSchema</code>.
+               of a verifiable credential is <code>https://www.w3.org/ns/credentials#jsonSchema</code>.
             </p>
             <p>
                Any version of [[JSON-SCHEMA]] in the section on

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
                    </tr>
                    <tr>
                       <td>type</td>
-                      <td>The <code>type</code> property MUST be JsonSchema.</td>
+                      <td>The <code>type</code> property MUST be <code>JsonSchema</code>.</td>
                    </tr>
                 </tbody>
              </table>
@@ -279,14 +279,7 @@
                of a verifiable credential is <code>https://www.w3.org/ns/credentials#JsonSchema</code>.
             </p>
             <p>
-               When defining a credential schema using the <code>JsonSchemaCredential</code> type,
-               the credential's <code>credentialSubject</code> MUST use the <a href="#jsonschema">JsonSchema</a> 
-               <code>type</code> value and make use of the <code>jsonSchema</code> property, as exemplified below.
-               The <code>credentialSubject</code> MAY have an <code>id</code> property, and if present, 
-               the value MUST match the <code>$id</code> property in the <code>jsonSchema</code> property.
-            </p>
-            <p>
-               Any version of [[JSON-Schema]] in the section on
+               Any version of [[JSON-SCHEMA]] in the section on
                <a href="#json-schema-specifications">JSON Schema Specifications</a>
                can be used.
             </p>
@@ -307,7 +300,23 @@
                    </tr>
                    <tr>
                       <td>type</td>
-                      <td>The <code>type</code> property MUST be JsonSchemaCredential</td>
+                      <td>The <code>type</code> property MUST be <code>JsonSchemaCredential</code>.</td>
+                   </tr>
+                   <tr>
+                      <td>credentialSubject.id</td>
+                      <td>The <code>credentialSubject</code>'s <code>id</code> property MUST be follow the guidance
+                        provided for <a data-cite="vc-data-model#identifiers">identifiers</a> in the [[VC-DATA-MODEL-2]] 
+                        specification.</td>
+                   </tr>
+                   <tr>
+                      <td>credentialSubject.type</td>
+                      <td>The <code>credentialSubject</code>'s <code>type</code> property MUST be 
+                        <a href="#jsonschema">JsonSchema.</td>
+                   </tr>
+                   <tr>
+                      <td>credentialSubject.jsonSchema</td>
+                      <td>The <code>credentialSubject</code> MUST use the <code>jsonSchema</code> property to 
+                        represent a valid [[JSON-SCHEMA]].</td>
                    </tr>
                 </tbody>
                </table>

--- a/index.html
+++ b/index.html
@@ -279,7 +279,14 @@
                of a verifiable credential is <code>https://www.w3.org/ns/credentials#JsonSchema</code>.
             </p>
             <p>
-               The specification version of [[JSON-Schema]] can be any version noted in the section
+               When defining a credential schema using the <code>JsonSchemaCredential</code> type,
+               the credential's <code>credentialSubject</code> MUST use the <a href="#jsonschema">JsonSchema</a> 
+               <code>type</code> value and make use of the <code>jsonSchema</code> property, as exemplified below.
+               The <code>credentialSubject</code> MAY have an <code>id</code> property, and if present, 
+               the value MUST match the <code>$id</code> property in the <code>jsonSchema</code> property.
+            </p>
+            <p>
+               Any version of [[JSON-Schema]] can be used from the section
                on <a href="#json-schema-specifications">JSON Schema Specifications</a>.
             </p>
             <p>


### PR DESCRIPTION
- guidance on the id property
- requiring the use of the JsonSchema type and jsonSchema properties


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/199.html" title="Last updated on Aug 14, 2023, 10:24 PM UTC (f0bbbbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/199/dc8c196...f0bbbbe.html" title="Last updated on Aug 14, 2023, 10:24 PM UTC (f0bbbbe)">Diff</a>