### PR TITLE
Clarified the value of `credentialSchema` when type is JsonSchemaCredential

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,14 +265,32 @@
                <b>JsonSchemaCredential</b> is used for the validation of W3C Verifiable Credentials using
                JSON Schema, where the JSON Schema is contained with a <a>verifiable credential</a>.
                When dereferencing the <code>id</code> property associated with the
-               <code>JsonSchemaCredential</code> <code>type</code> value the result is a valid 
-               <a>verifiable credential</a>. The resulting <a>verifiable credential</a>'s  
-               <code>credentialSubject</code> property MUST contain a two properties:
-               <ul>
+               <code>credentialSchema</code> <code>type</code> value, the result is a valid
+               <a>verifiable credential</a>. For the resulting <a>verifiable credential</a>:
+            <p>
+            <ul>
+              <li>
+                The <code>credentialSubject</code> property MUST contain two properties:
+                <ul>
                   <li><code>type</code> – the value of which MUST be <code>JsonSchema</code></li>
                   <li><code>jsonSchema</code> – an object which contains a valid JSON Schema</li>
-               </ul>
-            </p>
+                </ul>
+              </li>
+              <li>
+                The value of the <code>credentialSchema</code> property MUST always be set to:
+                <pre title="Value of a JsonSchemaCredential's credentialSchema property">
+                {
+                  "id": "https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json",
+                  "type": "JsonSchema",
+                  "digestSRI": "sha384-S57yQDg1MTzF56Oi9DbSQ14u7jBy0RDdx0YbeV7shwhCS88G8SCXeFq82PafhCrW"
+                }
+                </pre>
+                <p class="note" title="The digestSRI value may change">
+                  The value of the <code>digestSRI</code> property may change until this specification becomes a recommendation.
+                </p>
+              </li>
+            </ul>
+
             <p>
                The <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
                for using the <code>jsonSchema</code> property within the <code>credentialSubject</code>
@@ -311,7 +329,7 @@
                    <tr>
                       <td>credentialSubject.type</td>
                       <td>The <code>credentialSubject</code>'s <code>type</code> property MUST be 
-                        <a href="#jsonschema">JsonSchema.</td>
+                        <a href="#jsonschema">JsonSchema</a>.</td>
                    </tr>
                    <tr>
                       <td>credentialSubject.jsonSchema</td>

--- a/index.html
+++ b/index.html
@@ -379,6 +379,11 @@
                 "type": ["VerifiableCredential", "JsonSchemaCredential"],
                 "issuer": "https://example.com/issuers/14",
                 "issuanceDate": "2010-01-01T19:23:24Z",
+                "credentialSchema": {
+                  "id": "https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json",
+                  "type": "JsonSchema",
+                  "digestSRI": "sha384-S57yQDg1MTzF56Oi9DbSQ14u7jBy0RDdx0YbeV7shwhCS88G8SCXeFq82PafhCrW"
+                },
                 "credentialSubject": {
                   "id": "https://example.com/schemas/email-credential-schema.json",
                   "type": "JsonSchema",

--- a/index.html
+++ b/index.html
@@ -285,8 +285,9 @@
                   "digestSRI": "sha384-S57yQDg1MTzF56Oi9DbSQ14u7jBy0RDdx0YbeV7shwhCS88G8SCXeFq82PafhCrW"
                 }
                 </pre>
-                <p class="note" title="The digestSRI value may change">
-                  The value of the <code>digestSRI</code> property may change until this specification becomes a recommendation.
+                <p class="issue" title="Hash values might change during Candidate Recommendation">
+                  The hash value of the <code>digestSRI</code> property might change during the Candidate Recommendation
+                  phase based on implementer feedback that requires the referenced files to be modified.
                 </p>
               </li>
             </ul>

--- a/schema/json-schema-credential-schema.json
+++ b/schema/json-schema-credential-schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json",
+  "description": "JSON Schema for a Verifiable Credential of type JsonSchemaCredential according to the Verifiable Credentials Data Model v2",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "array",
+      "const": [
+        "VerifiableCredential",
+        "JsonSchemaCredential"
+      ]
+    },
+    "credentialSubject": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "JsonSchema"
+        },
+        "jsonSchema": {
+          "anyOf": [
+            {
+              "$ref": "https://json-schema.org/draft/2020-12/schema"
+            },
+            {
+              "$ref": "https://json-schema.org/draft/2019-09/schema"
+            },
+            {
+              "$ref": "http://json-schema.org/draft-07/schema"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "jsonSchema"
+      ]
+    },
+    "credentialSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "const": "https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json"
+        },
+        "type": {
+          "type": "string",
+          "const": "JsonSchema"
+        },
+        "digestSRI": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "digestSRI"
+      ]
+    }
+  },
+  "required": [
+    "type",
+    "credentialSubject",
+    "credentialSchema"
+  ]
+}


### PR DESCRIPTION
This fixed #159 by making it clear what the value of `credentialSchema` MUST be. This prevents any infinite recursions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/204.html" title="Last updated on Aug 18, 2023, 5:07 PM UTC (593929a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/204/2eda973...593929a.html" title="Last updated on Aug 18, 2023, 5:07 PM UTC (593929a)">Diff</a>