### PR TITLE
Encourage OHTTP to prevent linking schema requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -1078,6 +1078,10 @@
          </section>
          <section class="informative">
             <h3>Schema Resolution</h3>
+           <p>
+             <a>Schema resolution</a> is the process of dereferencing a credential schema's identifier in order to fetch a
+             <a>credential schema</a>.
+           </p>
             <p>
                <a>Issuers</a> can increase the privacy of <a>holders</a> by using
                content distribution networks to reduce or eliminate requests for the

--- a/index.html
+++ b/index.html
@@ -1077,15 +1077,21 @@
             </p>
          </section>
          <section class="informative">
-            <h3>Content Distribution Networks</h3>
+            <h3>Schema Resolution</h3>
             <p>
                The use of content distribution networks by <a>issuers</a> can increase the
                privacy of <a>holders</a> by reducing or eliminating requests for the
-               schemas lists from the <a>issuer</a>. Often, a request for a schema
-               list will be served by an edge device and thus be faster and reduce the load
+               schemas from the <a>issuer</a>. Often, a request for a schema
+               will be served by an edge device and thus be faster and reduce the load
                on the server as well as cloaking <a>verifiers</a> and <a>holders</a>
                from <a>issuers</a>.
             </p>
+           <p>
+             Furthermore, the use of <a href="https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html">Oblivious HTTP</a>
+             can prevent linking schema requests made by <a>holders</a>. It is encouraged that implementers allow configuration
+             of an <a href="https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html#dfn-relay">Oblivious Relay Resource</a>
+             to be used when doing <a>schema resolution</a>.
+           </p>
          </section>
       </section>
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -1079,8 +1079,8 @@
          <section class="informative">
             <h3>Schema Resolution</h3>
             <p>
-               The use of content distribution networks by <a>issuers</a> can increase the
-               privacy of <a>holders</a> by reducing or eliminating requests for the
+               <a>Issuers</a> can increase the privacy of <a>holders</a> by using
+               content distribution networks to reduce or eliminate requests for the
                schemas from the <a>issuer</a>. Often, a request for a schema
                will be served by an edge device and thus be faster and reduce the load
                on the server as well as cloaking <a>verifiers</a> and <a>holders</a>
@@ -1088,9 +1088,9 @@
             </p>
            <p>
              Furthermore, the use of <a href="https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html">Oblivious HTTP</a>
-             can prevent linking schema requests made by <a>holders</a>. It is encouraged that implementers allow configuration
+             can prevent linkage of schema requests made by <a>holders</a>. Implementers are encouraged to allow configuration
              of an <a href="https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html#dfn-relay">Oblivious Relay Resource</a>
-             to be used when doing <a>schema resolution</a>.
+             for use during <a>schema resolution</a>.
            </p>
          </section>
       </section>


### PR DESCRIPTION
Fixes #203


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/207.html" title="Last updated on Aug 21, 2023, 5:35 PM UTC (305fb52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/207/07b4ae3...305fb52.html" title="Last updated on Aug 21, 2023, 5:35 PM UTC (305fb52)">Diff</a>