### PR TITLE
Add test suite to readme; term definition for jsonschema

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ https://w3c.github.io/vc-json-schema/
 We encourage contributions meeting the [Contribution Guidelines](CONTRIBUTING.md).  While we prefer the creation of issues
 and Pull Requests in the GitHub repository, discussions may also occur on the [public-credentials](http://lists.w3.org/Archives/Public/public-credentials/) mailing list.
 
+### Test Suite
+
+A [docker](https://www.docker.com/)-based test suite for the specification can [be found here](https://github.com/w3c/vc-json-schema-test-suite). All impelementers are encouraged to add to the test suite.
+
 ### Building
 
 To build, we use [respec](https://respec.org/).
@@ -21,3 +25,6 @@ Next open up `out.html` in a web browser and review the document.
 
 ### Other useful links
 * [Public group email archive](https://lists.w3.org/Archives/Public/public-credentials/)
+* [VC Data Model](https://www.w3.org/TR/vc-data-model/)
+* [JSON Schema](https://json-schema.org/)
+* [Test Suite](https://github.com/w3c/vc-json-schema-test-suite)

--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@
                    <tr>
                       <td>id</td>
                       <td>The constraints on the <code>id</code> property are listed in the Verifiable Credentials
-                      Data Model specification [[VC-DATA-MODEL-2]]. The value MUST be a URL that identifies
+                      Data Model specification [[VC-DATA-MODEL-2]]. The value MUST be a <a>URL</a> that identifies
                       the <a>verifiable credential</a> which contains a credential schema.</td>
                    </tr>
                    <tr>
@@ -539,7 +539,7 @@
                <p>
                   It is RECOMMENDED that the value of the <code>$id</code> property match the <code>id</code>
                   value in the <code>credentialSchema</code> object of a <a>verifiable credential</a>, and
-                  that the value of the <code>$id</code> is a dereferenceable URL [[URL]].
+                  that the value of the <code>$id</code> is a dereferenceable <a>URL</a>.
                </p>
             </section>
             <section class="normative">

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
            github: "https://github.com/w3c/vc-json-schema/",
            includePermalinks: false,
            edDraftURI: "https://w3c.github.io/vc-json-schema/",
+           testSuiteURI: "https://w3c.github.io/vc-json-schema-test-suite/",
            editors: [{
              name: "Gabe Cohen",
              url: "https://github.com/decentralgabe",
@@ -273,7 +274,7 @@
                 The <code>credentialSubject</code> property MUST contain two properties:
                 <ul>
                   <li><code>type</code> – the value of which MUST be <code>JsonSchema</code></li>
-                  <li><code>jsonSchema</code> – an object which contains a valid JSON Schema</li>
+                  <li><a href="jsonschema-0"><code>jsonSchema</code></a> – an object which contains a valid JSON Schema</li>
                 </ul>
               </li>
               <li>
@@ -291,12 +292,6 @@
                 </p>
               </li>
             </ul>
-
-            <p>
-               The <a href="https://www.w3.org/TR/json-ld/#dfn-term-definition">term definition</a>
-               for using the <code>jsonSchema</code> property within the <code>credentialSubject</code>
-               of a verifiable credential is <code>https://www.w3.org/ns/credentials#jsonSchema</code>.
-            </p>
             <p>
                Any version of [[JSON-SCHEMA]] in the section on
                <a href="#json-schema-specifications">JSON Schema Specifications</a>
@@ -410,10 +405,60 @@
               }
               </pre>
             </p>
-            <p class="issue" data-number="159">
-               Add language about JsonSchemaCredential credentials having a credentialSchema property
-               and the risks of nesting.
-            </p>
+            <section class="normative">
+               <h4>jsonSchema</h4>
+               <p>
+                  This term is part of the 
+                  <a href="https://www.w3.org/2018/credentials/#JsonSchemaCredential">Verifiable Credentials Vocabulary v2.0</a>.
+               </p>
+               <p><b>jsonSchema</b> enables the use of the <code>jsonSchema</code> property
+                  within the <code>credentialSubject</code> of a verifiable credential.  The term is
+                  intended to be used with the <a href="#jsonschemacredential"></a> type. The value of
+                  the <code>jsonSchema</code> property MUST be a valid [[JSON-SCHEMA]].
+               </p>
+               <p>
+                  <pre class="example jsonschemacredential-jsonschema nohighlight" title="Example JsonSchema Credential with jsonSchema">
+                  {
+                   "@context": [
+                       "https://www.w3.org/ns/credentials/v2",
+                       "https://www.w3.org/ns/credentials/examples/v2"
+                   ],
+                   "id": "https://example.com/credentials/3734",
+                   "type": ["VerifiableCredential", "JsonSchemaCredential"],
+                   "issuer": "https://example.com/issuers/14",
+                   "issuanceDate": "2010-01-01T19:23:24Z",
+                   "credentialSchema": {
+                     "id": "https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json",
+                     "type": "JsonSchema",
+                   },
+                   "credentialSubject": {
+                     "id": "https://example.com/schemas/favorite-color-schema.json",
+                     "type": "JsonSchema",
+                     <span class="highlight"> "jsonSchema": {
+                        "$id": "https://example.com/schemas/favorite-color-schema.json",
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "name": "Favorite Color Schema",
+                        "description": "Favorite Color using JsonSchemaCredential",
+                        "type": "object",
+                        "properties": {
+                          "credentialSubject": {
+                            "type": "object",
+                            "properties": {
+                              "favoriteColor": {
+                                "type": "string"
+                                "enum": ["red", "orange", "green", "blue", "yellow", "purple"]
+                              }
+                            },
+                            "required": ["favoriteColor"]
+                          }
+                        }
+                     }
+                     </span>
+                   }
+                 }
+                 </pre>
+               </p>
+            </section>
          </section>
       </section>
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -201,6 +201,11 @@
                 </tbody>
              </table>
             </p>
+            <p class="note" title="Restriction on the usage of the jsonSchema property">
+               Usage of the <code><a href="#jsonschema-0">jsonSchema</a></code> property is restricted to
+               situations where the <code>JsonSchema</code> class instance is the object of the <code>credentialSubject</code>
+               property within a <code><a href="#jsonschemacredential">JsonSchemaCredential</a></code> instance.
+            </p>
             <p>
                An example of utilizing the VC Data Model's <code>credentialSchema</code>
                is provided below:
@@ -506,7 +511,7 @@
           <p class="note" title="A stable JSON Schema specification is coming">
            <a href="https://json-schema.org/blog/posts/future-of-json-schema">A stable JSON Schema specification</a>
            is in the works. When it's released, we intend to update this table to require the stable version.
-         </p>
+          </p>
 
           <section class="normative">
             <h3>Reserved Keywords</h3>

--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@
                <h4>jsonSchema</h4>
                <p>
                   This term is part of the 
-                  <a href="https://www.w3.org/2018/credentials/#JsonSchemaCredential">Verifiable Credentials Vocabulary v2.0</a>.
+                  <a href="https://www.w3.org/2018/credentials/#jsonSchema">Verifiable Credentials Vocabulary v2.0</a>.
                </p>
                <p><b>jsonSchema</b> enables the use of the <code>jsonSchema</code> property
                   within the <code>credentialSubject</code> of a verifiable credential.  The term is

--- a/index.html
+++ b/index.html
@@ -418,7 +418,7 @@
                </p>
                <p><b>jsonSchema</b> enables the use of the <code>jsonSchema</code> property
                   within the <code>credentialSubject</code> of a verifiable credential.  The term is
-                  intended to be used with the <a href="#jsonschemacredential"></a> type. The value of
+                  intended to be used with the <a href="#jsonschemacredential"></a> type only. The value of
                   the <code>jsonSchema</code> property MUST be a valid [[JSON-SCHEMA]].
                </p>
                <p>

--- a/terms.html
+++ b/terms.html
@@ -95,11 +95,6 @@ information to share.
   <dd>
 A thing about which <a>claims</a> are made.
   </dd>
-  <dt><dfn class="lint-ignore">user agent</dfn></dt>
-  <dd>
-A program, such as a browser or other Web client, that mediates the
-communication between <a>holders</a>, <a>issuers</a>, and <a>verifiers</a>.
-  </dd>
   <dt><dfn data-lt="credential validation">validation</dfn></dt>
   <dd>
 The assurance that a <a>verifiable credential</a> or a


### PR DESCRIPTION
Add href-able term definition for `jsonSchema`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/211.html" title="Last updated on Sep 6, 2023, 5:35 PM UTC (c1d214b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/211/9c37640...c1d214b.html" title="Last updated on Sep 6, 2023, 5:35 PM UTC (c1d214b)">Diff</a>