### PR TITLE
Renamed `name` to `title` and added `lang` & `dir`.

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -44,7 +44,7 @@ Before constructing or issuing a verifiable credential, there must first be a JS
 {
   "$id": "https://example.com/schemas/email.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "name": "EmailCredential",
+  "title": "EmailCredential",
   "description": "EmailCredential using JsonSchema2023",
   "type": "object",
   "properties": {
@@ -104,7 +104,7 @@ Before constructing or issuing a verifiable credential, there must first be a JS
   "credentialSubject": {
     "$id": "https://example.com/schemas/email-credential-schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "name": "EmailCredential",
+    "title": "EmailCredential",
     "description": "EmailCredential using CredentialSchema2023",
     "type": "object",
     "properties": {

--- a/example/yaml-json-schema.yaml
+++ b/example/yaml-json-schema.yaml
@@ -1,7 +1,7 @@
 ---
 "$id": https://example.com/schemas/email.json
 "$schema": https://json-schema.org/draft/2020-12/schema
-name: Email Credential Schema
+title: Email Credential Schema
 description: Email Credential JSON Schema using YAML
 type: object
 properties:
@@ -17,7 +17,7 @@ example: |-
   {
     "$id": "https://example.com/schemas/email.json",
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "name": "EmailCredential",
+    "title": "EmailCredential",
     "description": "Email Credential JSON Schema",
     "type": "object",
     "properties": {

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
               {
                 "$id": "https://example.com/schemas/email.json",
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "name": "EmailCredential",
+                "title": "EmailCredential",
                 "description": "EmailCredential using JsonSchema",
                 "type": "object",
                 "properties": {
@@ -397,7 +397,7 @@
                   "jsonSchema": {
                      "$id": "https://example.com/schemas/email-credential-schema.json",
                      "$schema": "https://json-schema.org/draft/2020-12/schema",
-                     "name": "EmailCredential",
+                     "title": "EmailCredential",
                      "description": "EmailCredential using JsonSchemaCredential",
                      "type": "object",
                      "properties": {
@@ -449,7 +449,7 @@
                      <span class="highlight"> "jsonSchema": {
                         "$id": "https://example.com/schemas/favorite-color-schema.json",
                         "$schema": "https://json-schema.org/draft/2020-12/schema",
-                        "name": "Favorite Color Schema",
+                        "title": "Favorite Color Schema",
                         "description": "Favorite Color using JsonSchemaCredential",
                         "type": "object",
                         "properties": {
@@ -560,17 +560,27 @@
                </p>
             </section>
             <section class="normative">
-               <h4>name</h4>
+               <h4>title</h4>
                <p>
-                  It is RECOMMENDED that all JSON Schemas include a <code>name</code> property which provides
-                  a human-readable name that describes the schema.
+                  It is RECOMMENDED that all JSON Schemas include the optional <code>title</code> property as defined in
+                  [[JSON-SCHEMA]].
                </p>
             </section>
             <section class="normative">
                <h4>description</h4>
                <p>
-                  JSON Schemas MAY choose to include an optional <code>description</code> property which provides
-                  a human-readable sentence describing the schema.
+                  It is RECOMMENDED that all JSON Schemas include the optional <code>description</code> property as
+                  defined in [[JSON-SCHEMA]].
+               </p>
+            </section>
+            <section class="normative">
+               <h4>locale</h4>
+               <p>
+                  JSON Schemas MAY choose to include an optional <code>locale</code> property to indicate the locale
+                  for the <a href="#title-0">title</a> and <a href="#description">description</a> properties defined in
+                  the JSON Schema. The value of this field MUST be a
+                  <a data-cite="ltli/#dfn-canonical-unicode-locale-identifier">canonical unicode locale identifier</a>.
+                  When absent, implementers MUST assume that the value of this property is `en-US`.
                </p>
             </section>
           </section>
@@ -689,7 +699,7 @@
                {
                  "$id": "https://example.com/schemas/email.json",
                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                 "name": "EmailCredential",
+                 "title": "EmailCredential",
                  "description": "EmailCredential using JsonSchema",
                  "type": "object",
                  "properties": {
@@ -774,7 +784,7 @@
                 {
                   "$id": "https://example.com/schemas/email.json",
                   "$schema": "https://json-schema.org/draft/2019-09/schema",
-                  "name": "EmailCredential",
+                  "title": "EmailCredential",
                   "description": "EmailCredential using JsonSchema",
                   "type": "object",
                   "properties": {
@@ -843,7 +853,7 @@
             {
               "$id": "validuntil-and-evidence-schema",
               "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "name": "Example validUntil and evidence schema",
+              "title": "Example validUntil and evidence schema",
               "description": "Schema requiring validUntil and evidence properties",
               "type": "object",
               "properties": {
@@ -880,7 +890,7 @@
             {
               "$id": "name-schema",
               "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "name": "Name schema",
+              "title": "Name schema",
               "description": "A schema capturing a human name",
               "type": "object",
               "properties": {
@@ -961,7 +971,7 @@
                 {
                   "$id": "name-schema",
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "name": "Name schema",
+                  "title": "Name schema",
                   "description": "A schema capturing a human name",
                   "type": "object",
                   "properties": {
@@ -991,7 +1001,7 @@
                 {
                   "$id": "email-schema-1.0",
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "name": "Email schema",
+                  "title": "Email schema",
                   "description": "A schema requiring an email address.",
                   "type": "object",
                   "properties": {
@@ -1094,7 +1104,7 @@
               {
                 "$id": "https://example.com/schemas/email.json",
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "name": "Email Credential",
+                "title": "Email Credential",
                 "description": "Email Credential Schema for usage in JsonSchema",
                 "type": "object",
                 "properties": {

--- a/index.html
+++ b/index.html
@@ -560,25 +560,57 @@
                </p>
             </section>
             <section class="normative">
-               <h4>title</h4>
+               <h4><dfn>title</dfn></h4>
                <p>
                   It is RECOMMENDED that all JSON Schemas include the optional <code>title</code> property as defined in
                   [[JSON-SCHEMA]].
                </p>
             </section>
             <section class="normative">
-               <h4>description</h4>
+               <h4><dfn>description</dfn></h4>
                <p>
                   It is RECOMMENDED that all JSON Schemas include the optional <code>description</code> property as
                   defined in [[JSON-SCHEMA]].
                </p>
             </section>
             <section class="normative">
-               <h4>locale</h4>
+               <h4>dir</h4>
                <p>
-                  JSON Schemas MAY choose to include an optional <code>locale</code> property to indicate the locale
-                  for the <a href="#title-0">title</a> and <a href="#description">description</a> properties defined in
-                  the JSON Schema. The value of this field MUST be a
+                  JSON Schemas MAY choose to include an optional <code>dir</code> property that indicates the
+                  base direction for the values of the [=title=] and [=description=] properties defined in
+                  the JSON Schema. The value of this property MUST be a <a>text-direction</a>. When absent, implementers
+                  MUST assume that the value of this property is "[=text-direction/auto=]".
+               </p>
+              <p>
+                The <dfn>text-directions</dfn> are the following:
+              </p>
+              <dl>
+                <dt>
+                  "<dfn data-dfn-for="text-direction">ltr</dfn>"
+                </dt>
+                <dd>
+                  Left-to-right text.
+                </dd>
+                <dt>
+                  "<dfn data-dfn-for="text-direction">rtl</dfn>"
+                </dt>
+                <dd>
+                  Right-to-left text.
+                </dd>
+                <dt>
+                  "<dfn data-dfn-for="text-direction">auto</dfn>" (default)
+                </dt>
+                <dd>
+                  No explicit directionality.
+                </dd>
+              </dl>
+            </section>
+            <section class="normative">
+               <h4>lang</h4>
+               <p>
+                 JSON Schemas MAY choose to include an optional <code>lang</code> property that indicates the
+                 <a data-cite="ltli/#dfn-language-tag">language tag</a> for the values of the [=title=] and
+                 [=description=] properties defined in the JSON Schema. The value of this field MUST be a
                   <a data-cite="ltli/#dfn-canonical-unicode-locale-identifier">canonical unicode locale identifier</a>.
                   When absent, implementers MUST assume that the value of this property is `en-US`.
                </p>


### PR DESCRIPTION
Fixes #224 by adding a `locale` field. 

Additionally, this PR also renames `name` in favor of `title`, because the latter is part of the json schema [spec](https://json-schema.org/understanding-json-schema/reference/annotations).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/225.html" title="Last updated on Nov 3, 2023, 12:04 AM UTC (7ccc3dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/225/1f2cd01...7ccc3dd.html" title="Last updated on Nov 3, 2023, 12:04 AM UTC (7ccc3dd)">Diff</a>