### PR TITLE
Correct the official schema URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
                 The value of the <code>credentialSchema</code> property MUST always be set to:
                 <pre title="Value of a JsonSchemaCredential's credentialSchema property">
                 {
-                  "id": "https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json",
+                  "id": "https://www.w3.org/ns/credentials/json-schema/v2.json",
                   "type": "JsonSchema",
                   "digestSRI": "sha384-S57yQDg1MTzF56Oi9DbSQ14u7jBy0RDdx0YbeV7shwhCS88G8SCXeFq82PafhCrW"
                 }
@@ -387,7 +387,7 @@
                 "issuer": "https://example.com/issuers/14",
                 "issuanceDate": "2010-01-01T19:23:24Z",
                 "credentialSchema": {
-                  "id": "https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json",
+                  "id": "https://www.w3.org/ns/credentials/json-schema/v2.json",
                   "type": "JsonSchema",
                   "digestSRI": "sha384-S57yQDg1MTzF56Oi9DbSQ14u7jBy0RDdx0YbeV7shwhCS88G8SCXeFq82PafhCrW"
                 },
@@ -440,7 +440,7 @@
                    "issuer": "https://example.com/issuers/14",
                    "issuanceDate": "2010-01-01T19:23:24Z",
                    "credentialSchema": {
-                     "id": "https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json",
+                     "id": "https://www.w3.org/ns/credentials/json-schema/v2.json",
                      "type": "JsonSchema",
                    },
                    "credentialSubject": {


### PR DESCRIPTION
Per https://github.com/w3c/vc-json-schema/issues/234 the following URL:

`https://www.w3.org/2022/credentials/v2/json-schema-credential-schema.json`

has now been replaced by 

`https://www.w3.org/ns/credentials/json-schema/v2.json`

This PR is just a global search and replace for those. The new URL is also alive (see  https://github.com/w3c/vc-json-schema/issues/234#issuecomment-2345376124).

@decentralgabe, I do not know whether there are other places in the spec (or other files) where a similar change should be done.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/pull/237.html" title="Last updated on Sep 12, 2024, 5:08 PM UTC (09ca120)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/237/84e8858...09ca120.html" title="Last updated on Sep 12, 2024, 5:08 PM UTC (09ca120)">Diff</a>