### PR TITLE
remove references to older schema drafts

### DIFF
--- a/example/yaml-json-schema.yaml
+++ b/example/yaml-json-schema.yaml
@@ -12,11 +12,11 @@ properties:
         type: string
         format: email
     required:
-    - emailAddress
+      - emailAddress
 example: |-
   {
     "$id": "https://example.com/schemas/email.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "EmailCredential",
     "description": "Email Credential JSON Schema",
     "type": "object",

--- a/index.html
+++ b/index.html
@@ -500,18 +500,6 @@
                    <td><a href="https://json-schema.org/draft/2020-12/schema">https://json-schema.org/draft/2020-12/schema</a></td>
                    <td>Yes</td>
                 </tr>
-                <tr>
-                   <td>[[?JSON-SCHEMA-2019-09]]</td>
-                   <td>19 March 2020</td>
-                   <td><a href="https://json-schema.org/draft/2019-09/schema">https://json-schema.org/draft/2019-09/schema</a></td>
-                   <td>No</td>
-                </tr>
-                <tr>
-                   <td>[[?JSON-SCHEMA-DRAFT-7]]</td>
-                   <td>20 September 2018</td>
-                   <td><a href="http://json-schema.org/draft-07/schema#">http://json-schema.org/draft-07/schema#</a></td>
-                   <td>No</td>
-                </tr>
              </tbody>
           </table>
 

--- a/schema/json-schema-credential-schema.json
+++ b/schema/json-schema-credential-schema.json
@@ -19,17 +19,7 @@
           "const": "JsonSchema"
         },
         "jsonSchema": {
-          "anyOf": [
-            {
-              "$ref": "https://json-schema.org/draft/2020-12/schema"
-            },
-            {
-              "$ref": "https://json-schema.org/draft/2019-09/schema"
-            },
-            {
-              "$ref": "http://json-schema.org/draft-07/schema"
-            }
-          ]
+          "$ref": "https://json-schema.org/draft/2020-12/schema"
         }
       },
       "required": [


### PR DESCRIPTION
fixes #239 by removing all references to Schema Draft 2019 except in the Indeterminate evaluation section: 
![image](https://github.com/user-attachments/assets/89126811-4ed2-4e26-aa0e-5ee8e5619e04)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mkhraisha/vc-json-schema/pull/243.html" title="Last updated on Jan 25, 2025, 6:41 PM UTC (1466306)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-json-schema/243/b6878b3...mkhraisha:1466306.html" title="Last updated on Jan 25, 2025, 6:41 PM UTC (1466306)">Diff</a>